### PR TITLE
WL-2580 Stop confusing JSF by not following beans.

### DIFF
--- a/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
+++ b/messageforums-app/src/java/org/sakaiproject/tool/messageforums/DiscussionForumTool.java
@@ -4058,7 +4058,7 @@ public class DiscussionForumTool
 	
     attachments.clear();
 
-    if (Boolean.parseBoolean(selectedForum.getMarkupFree())) {
+    if (selectedForum.getMarkupFree()) {
     	composeBody = messageParsingService.format(selectedMessage.getMessage().getBody());
     } else {
     	composeBody = selectedMessage.getMessage().getBody();
@@ -7869,7 +7869,7 @@ public class DiscussionForumTool
 		Session session = SessionManager.getCurrentSession();
 		String rv = (session.getAttribute("is_wireless_device") != null &&
 					((Boolean) session.getAttribute("is_wireless_device")).booleanValue()) ||
-					Boolean.parseBoolean(selectedForum.getMarkupFree()) ? 
+					selectedForum.getMarkupFree() ? 
 							"true":"false"; 
 		return rv;
 	}
@@ -7895,7 +7895,7 @@ public class DiscussionForumTool
 		DiscussionForumBean forum = getSelectedForum();
 		// Topic might be null if it's a PrivateMessage
 		if (forum != null) {
-			markupFree = forum.isMarkupFree();
+			markupFree = Boolean.valueOf(forum.getMarkupFree());
 		} else {
 			LOG.warn("No forum to find the markup free flag from.");
 		}

--- a/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
+++ b/messageforums-app/src/java/org/sakaiproject/tool/messageforums/ui/DiscussionForumBean.java
@@ -232,28 +232,19 @@ public class DiscussionForumBean
   /**
    * Return whether or not the forum is markup free.
    */
-  public String getMarkupFree()
+  public boolean getMarkupFree()
   {
 	  LOG.debug("getMarkupFree()");
-	  return Boolean.toString(forum.getMarkupFree());
+	  return forum.getMarkupFree();
   }
 
   /**
-   * Return whether or not the forum is markup free.
-   */
-  public boolean isMarkupFree()
-  {
-	  LOG.debug("isMarkupFree()");
-	  return forum.getMarkupFree();
-  }
-  
-  /**
    * Set the forum to accept text only messages.
    */
-  public void setMarkupFree(String markupFree)
+  public void setMarkupFree(boolean markupFree)
   {
 	  LOG.debug("setMarkupFree()");
-	  forum.setMarkupFree(Boolean.parseBoolean(markupFree));
+	  forum.setMarkupFree(markupFree);
   }
 
   /**


### PR DESCRIPTION
JSF was getting confused by not following the JavaBean convention of getters and setters so I've switched to just using a plain boolean rather than doing parsing all over the place.
