### PR TITLE
WL-2582 Fix for default of false matching.

### DIFF
--- a/messageforums-app/src/webapp/jsp/dfReviseForumSettingsAttach.jsp
+++ b/messageforums-app/src/webapp/jsp/dfReviseForumSettingsAttach.jsp
@@ -192,8 +192,8 @@
 				</h:panelGroup>
 				<h:panelGroup>
 					<h:selectOneRadio layout="lineDirection"  id="markup_free"  value="#{ForumTool.selectedForum.markupFree}"  styleClass="selectOneRadio">
-    					<f:selectItem itemValue="true" itemLabel="#{msgs.cdfm_yes}"/>
-    					<f:selectItem itemValue="false" itemLabel="#{msgs.cdfm_no}"/>
+    					<f:selectItem itemValue="#{true}" itemLabel="#{msgs.cdfm_yes}"/>
+    					<f:selectItem itemValue="#{false}" itemLabel="#{msgs.cdfm_no}"/>
   					</h:selectOneRadio>
 				</h:panelGroup>
 			</h:panelGrid>


### PR DESCRIPTION
When initially rendering the template JSF doesn't use property editors so the  string "false" isn't equal to the boolean false and so no default is selected.
