### PR TITLE
WL-4017 Added new method in Forums to get recent messages for a site.

### DIFF
--- a/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MessageForumsMessageManager.java
+++ b/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/MessageForumsMessageManager.java
@@ -248,4 +248,13 @@ public interface MessageForumsMessageManager {
 	public void saveMessageMoveHistory(Long msgid, Long desttopicId,Long sourceTopicId, boolean checkreminder);
 	  
 	public List findMovedMessagesByTopicId(Long id); 
+
+	/**
+	 * Returns a given number of recent threads(which are not deleted and not in draft stage)
+	 * for a given list of topicIds
+	 * @param topicIds
+	 * @param numberOfMessages
+	 * @return
+	 */
+	public List getRecentDiscussionForumThreadsByTopicIds(List<Long> topicIds, int numberOfMessages);
 }

--- a/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/ui/DiscussionForumManager.java
+++ b/messageforums-api/src/java/org/sakaiproject/api/app/messageforums/ui/DiscussionForumManager.java
@@ -597,4 +597,6 @@ public interface DiscussionForumManager
   public Set<String> getUsersAllowedForTopic(Long topicId, boolean checkReadPermission, boolean checkModeratePermission);
   
   public boolean canUserPostMessage(Long topicId, String methodCalled);
+
+  public List getRecentDiscussionForumThreadsByTopicIds(List<Long> topicIds, int numberOfMessages);
 }

--- a/messageforums-app/src/java/org/sakaiproject/tool/messageforums/entityproviders/ForumsEntityProviderImpl.java
+++ b/messageforums-app/src/java/org/sakaiproject/tool/messageforums/entityproviders/ForumsEntityProviderImpl.java
@@ -6,6 +6,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import lombok.Setter;
 
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sakaiproject.api.app.messageforums.Attachment;
@@ -46,6 +47,7 @@ public class ForumsEntityProviderImpl extends AbstractEntityProvider implements 
 	private static final Log LOG = LogFactory.getLog(ForumsEntityProviderImpl.class);
 
 	public final static String ENTITY_PREFIX = "forums";
+	public static int DEFAULT_NUM_MESSAGES = 3;
 	
 	@Setter
 	protected DiscussionForumManager forumManager;
@@ -335,13 +337,7 @@ public class ForumsEntityProviderImpl extends AbstractEntityProvider implements 
 		}
 		
 		Message fatMessage = forumManager.getMessageById(messageId);
-		//fatmessage has user_Id set in the 'modifiedBy' field, setting it to displayId for display purpose
-		try {
-			String displayId =  userDirectoryService.getUser(fatMessage.getModifiedBy()).getDisplayId();
-			fatMessage.setModifiedBy(displayId);
-		} catch (UserNotDefinedException e) {
-			LOG.debug(" User not defined for id '" + fatMessage.getModifiedBy() + "'.");
-		}
+
 		Topic fatTopic = forumManager.getTopicByIdWithMessagesAndAttachments(fatMessage.getTopic().getId());
 		
 		// This sets the attachments on the message.We have to do this as
@@ -442,5 +438,81 @@ public class ForumsEntityProviderImpl extends AbstractEntityProvider implements 
 		if(!toolManager.isVisible(site, toolConfig)) {
 			throw new EntityException("No access to tool in site: " + siteId, "",HttpServletResponse.SC_UNAUTHORIZED);
 		}
+	}
+
+	/**
+	 * Handles requests /direct/forums/messages/SITEID.json?n=10 and returns latest threads for a site
+	 * @param view
+	 * @param params
+	 * @return
+	 */
+	@EntityCustomAction(action="messages",viewKey=EntityView.VIEW_LIST)
+	public Object displayMessages(EntityView view, Map<String, Object> params) {
+
+		if(LOG.isDebugEnabled()) {
+			LOG.debug("handleSite");
+		}
+
+		//get number of messages to display from the URL params, validate and set to 0 if not set or conversion fails
+		int numberOfMessages = NumberUtils.toInt((String)params.get("n"), 0);
+		if(numberOfMessages == 0){
+			numberOfMessages = DEFAULT_NUM_MESSAGES;
+		}
+		String userId = developerHelperService.getCurrentUserId();
+
+		if(userId == null) {
+			LOG.error("Not logged in");
+			throw new EntityException("You must be logged in view conversations.","",HttpServletResponse.SC_UNAUTHORIZED);
+		}
+
+		String siteId = view.getPathSegment(2);
+
+		if(siteId == null) {
+			LOG.error("Bad request. No SITEID supplied on path.");
+			throw new EntityException("Bad request: To get the fora in a site you need a url like '/direct/forums/site/SITEID/latestmessages.json?n=10'"
+					,"",HttpServletResponse.SC_BAD_REQUEST);
+		}
+
+		checkSiteAndToolAccess(siteId);
+		List<SparseMessage> messages = new ArrayList<SparseMessage>();
+		//List of topicIds from all forums which are accessible to the user
+		List<Long> topicIds = new ArrayList<Long>();
+
+		//get all forums for the site
+		List<DiscussionForum> forums = forumManager.getDiscussionForumsWithTopics(siteId);
+		for(DiscussionForum forum : forums){
+			if( ! checkAccess(forum, userId)) {
+				LOG.debug("Access denied for user id '" + userId + "' to forum '" + forum.getId()
+						+ "'. Topic ids will not be added for this forum .");
+				continue;
+			}
+
+			for(Topic topic : (List<Topic>) forum.getTopics()) {
+				//check if user can see this topic
+				if(!uiPermissionsManager.isRead(topic.getId(),((DiscussionTopic)topic).getDraft(),false, userId, siteId)) {
+					//user has no permission so skip adding this topicId into the list.
+					continue;
+				}
+				topicIds.add(topic.getId());
+			}
+		}
+		//For given 'topicIds' fetch recently updated threads
+		for(Message fm : (List<Message>) forumManager.getRecentDiscussionForumThreadsByTopicIds(topicIds, numberOfMessages)) {
+			//message has user_Id set in the 'modifiedBy' field, setting it to 'displayId' for display purpose
+			try {
+				String displayId =  userDirectoryService.getUser(fm.getModifiedBy()).getDisplayId();
+				fm.setModifiedBy(displayId);
+			} catch (UserNotDefinedException e) {
+				LOG.debug(" User not defined for id '" + fm.getModifiedBy() + "'.");
+			}
+			SparseMessage sm = new SparseMessage(fm,/* readStatus =*/ false,/* addAttachments =*/ true, developerHelperService.getServerURL());
+			Topic topic = fm.getTopic();
+			//setting forumId for the sparse message
+			if(topic != null && topic.getBaseForum() != null) {
+				sm.setForumId(topic.getBaseForum().getId());
+			}
+			messages.add(sm);
+		}
+		return messages;
 	}
 }

--- a/messageforums-app/src/java/org/sakaiproject/tool/messageforums/entityproviders/sparsepojos/SparseMessage.java
+++ b/messageforums-app/src/java/org/sakaiproject/tool/messageforums/entityproviders/sparsepojos/SparseMessage.java
@@ -64,6 +64,9 @@ public class SparseMessage{
 
 	@Getter @Setter
 	private String modifiedBy;
+
+	//this is used for displaying recent messages in the lessons
+	private Long forumId;
 	 
 	public SparseMessage(Message fatMessage, Boolean readStatus, boolean addAttachments, String serverUrl) {
 		
@@ -124,5 +127,12 @@ public class SparseMessage{
 			replies = new ArrayList<SparseMessage>();
 		}
 		replies.add(reply);
+	}
+	public Long getForumId() {
+		return forumId;
+	}
+
+	public void setForumId(Long forumId) {
+		this.forumId = forumId;
 	}
 }

--- a/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
+++ b/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/MessageForumsMessageManagerImpl.java
@@ -2149,5 +2149,44 @@ public class MessageForumsMessageManagerImpl extends HibernateDaoSupport impleme
 		return (List) getHibernateTemplate().execute(hcb);        
 
 	}
-	   
+
+	public List getRecentDiscussionForumThreadsByTopicIds(final List<Long> topicIds, final int numberOfMessages) {
+		if (topicIds.isEmpty())
+		{
+			return new ArrayList<Object[]>();
+		}
+		if (LOG.isDebugEnabled())
+		{
+			LOG.debug("getRecentDiscussionForumThreadsByTopicIds executing for list of size: " + topicIds.size());
+		}
+		HibernateCallback hcb = new HibernateCallback() {
+			public Object doInHibernate(Session session) throws HibernateException, SQLException {
+				Query q = session.getNamedQuery("findRecentDiscussionForumThreadsByTopicIds");
+				q.setParameterList("topicIds", topicIds);
+				q.setMaxResults(numberOfMessages);
+				return q.list();
+			}
+		};
+
+		Message tempMsg = null;
+		Set resultSet = new HashSet();
+		List temp = (ArrayList) getHibernateTemplate().execute(hcb);
+		LOG.debug("got an initial list of " + temp.size());
+		for (Iterator i = temp.iterator(); i.hasNext();)
+		{
+			Object[] results = (Object[]) i.next();
+
+			if (results != null) {
+				if (results[0] instanceof Message) {
+					tempMsg = (Message)results[0];
+					tempMsg.setTopic((Topic)results[1]);
+					tempMsg.getTopic().setBaseForum((BaseForum)results[2]);
+				}
+				resultSet.add(tempMsg);
+			}
+		}
+
+		LOG.debug("about to return");
+		return Util.setToList(resultSet);
+	}
 }

--- a/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/ui/DiscussionForumManagerImpl.java
+++ b/messageforums-component-impl/src/java/org/sakaiproject/component/app/messageforums/ui/DiscussionForumManagerImpl.java
@@ -2602,4 +2602,13 @@ public abstract class DiscussionForumManagerImpl extends HibernateDaoSupport imp
 		String contextId = area.getContextId();
 	    return uiPermissionsManager().isNewResponseToResponse(topic, forum, contextId);
 	}
+
+	public List getRecentDiscussionForumThreadsByTopicIds(List<Long> topicIds, int numberOfMessages)
+	{
+		if (LOG.isDebugEnabled())
+		{
+			LOG.debug("getRecentDiscussionForumMessagesByContext( Size of list is " + topicIds.size() + ")");
+		}
+		return messageManager.getRecentDiscussionForumThreadsByTopicIds(topicIds, numberOfMessages);
+	}
 }

--- a/messageforums-hbm/src/java/org/sakaiproject/component/app/messageforums/dao/hibernate/MessageImpl.hbm.xml
+++ b/messageforums-hbm/src/java/org/sakaiproject/component/app/messageforums/dao/hibernate/MessageImpl.hbm.xml
@@ -808,6 +808,17 @@
              where area.contextId = :contextId and
              message.deleted = false]]>
   </query>
+
+    <!-- returns recent forum  threads for a given list of topicIds -->
+    <query name="findRecentDiscussionForumThreadsByTopicIds">
+        <![CDATA[select message, topic, forum from org.sakaiproject.component.app.messageforums.dao.hibernate.MessageImpl as message
+             join message.topic as topic
+             join topic.openForum as forum
+             where topic.id in (:topicIds) and
+             message.inReplyTo is null and
+             message.draft = false and
+             message.deleted = false ORDER BY message.modified desc]]>
+    </query>
   
   <!-- return all moved messages that need to be displayed as reminders -->
 <query name="findMovedMessagesByTopicId">


### PR DESCRIPTION
New method 'getRecentDiscussionForumMessagesByContext' added in
MessageForumsMessageManager to return given number of recent messages
for a given siteId.
Query(findRecentDiscussionForumMessagesInSite) to get recent forum messages
is added in MessageImpl.hbm.xml
New separate method 'displayMessages' added in ForumsEntityProviderImpl
to handle requests '/direct/forums/messages/SITEID.json?n=10'.
